### PR TITLE
Fix Chrome timeout in Travis builds

### DIFF
--- a/scripts/findChrome.js
+++ b/scripts/findChrome.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const { homedir } = require('os')
 const puppeteer = require('puppeteer-core')
-const { execSync, execFileSync } = require('child_process')
+const { execSync, execFileSync, exec } = require('child_process')
 const pptrCoreJson = require('puppeteer-core/package.json')
 const { writeFile } = require('../src/utils')
 
@@ -198,11 +198,11 @@ async function downloadChromium() {
   }
 }
 
-function isSuitableVersion(executablePath) {
+async function isSuitableVersion(executablePath) {
   let versionOutput
   // in case installed Chrome is not runnable
   try {
-    versionOutput = execSync(`${executablePath} --version`).toString()
+    versionOutput = await exec(`${executablePath} --version`).toString()
   } catch (e) {
     return false
   }

--- a/scripts/findChrome.js
+++ b/scripts/findChrome.js
@@ -197,6 +197,18 @@ async function downloadChromium() {
   }
 }
 
+function isSuitableVersion(executablePath) {
+  const versionOutput = execSync(`${executablePath} --version`).toString()
+  const versionRe = /(Google Chrome|Chromium) ([0-9]{2}).*/
+
+  const match = versionOutput.match(versionRe)
+  if (match && match[2]) {
+    const version = +match[2]
+    return version >= 75
+  }
+  return false
+}
+
 async function findChrome() {
   let executablePath
 
@@ -205,9 +217,11 @@ async function findChrome() {
   else if (process.platform === 'darwin') executablePath = darwin()
 
   if (typeof executablePath === 'string' && executablePath.length > 0) {
-    await writeFile(chromeConfigPath, JSON.stringify({ executablePath }))
-    console.log(`Local Chrome location: ${executablePath}`)
-    return executablePath
+    if (isSuitableVersion(executablePath)) {
+      await writeFile(chromeConfigPath, JSON.stringify({ executablePath }))
+      console.log(`Local Chrome location: ${executablePath}`)
+      return executablePath
+    }
   }
 
   const revisionInfo = await downloadChromium()

--- a/scripts/findChrome.js
+++ b/scripts/findChrome.js
@@ -6,6 +6,7 @@ const { execSync, execFileSync, exec } = require('child_process')
 const pptrCoreJson = require('puppeteer-core/package.json')
 const { writeFile } = require('../src/utils')
 
+const MIN_CHROME_VERSION = 75
 const newLineRegex = /\r?\n/
 const chromeTempPath = path.join(process.cwd(), 'temp', 'chrome')
 const chromeConfigPath = path.join(process.cwd(), 'chrome.json')
@@ -217,7 +218,7 @@ async function isSuitableVersion(executablePath) {
   const match = versionOutput.match(versionRe)
   if (match && match[2]) {
     const version = +match[2]
-    return version >= 75
+    return version >= MIN_CHROME_VERSION
   }
   return false
 }

--- a/scripts/findChrome.js
+++ b/scripts/findChrome.js
@@ -199,7 +199,13 @@ async function downloadChromium() {
 }
 
 function isSuitableVersion(executablePath) {
-  const versionOutput = execSync(`${executablePath} --version`).toString()
+  let versionOutput
+  // in case installed Chrome is not runnable
+  try {
+    versionOutput = execSync(`${executablePath} --version`).toString()
+  } catch (e) {
+    return false
+  }
   const versionRe = /(Google Chrome|Chromium) ([0-9]{2}).*/
 
   const match = versionOutput.match(versionRe)
@@ -218,11 +224,13 @@ async function findChrome() {
   else if (process.platform === 'darwin') executablePath = darwin()
 
   if (typeof executablePath === 'string' && executablePath.length > 0) {
+    // check whether installed Chrome major version is >= 75
     if (isSuitableVersion(executablePath)) {
       await writeFile(chromeConfigPath, JSON.stringify({ executablePath }))
       console.log(`Local Chrome location: ${executablePath}`)
       return executablePath
     }
+    console.log('Local Chrome version is not suitable')
   }
 
   const revisionInfo = await downloadChromium()

--- a/scripts/findChrome.js
+++ b/scripts/findChrome.js
@@ -171,7 +171,8 @@ async function downloadChromium() {
     path: chromeTempPath,
   })
 
-  const revision = pptrCoreJson.puppeteer.chromium_revision
+  const revision = process.env.PUPPETEER_CHROMIUM_REVISION || process.env.npm_config_puppeteer_chromium_revision
+    || process.env.npm_package_config_puppeteer_chromium_revision || pptrCoreJson.puppeteer.chromium_revision
   const revisionInfo = browserFetcher.revisionInfo(revision)
 
   // If already downloaded


### PR DESCRIPTION
Turns out, Travis image has its own Chrome, which doesn't want to start for some reason. So I added a version guard for it (>= 75) and additional env vars from puppeteer's `install.js`.

Fixes #9 
@ai