### PR TITLE
Add quotes around executablePath

### DIFF
--- a/scripts/chromeDetection.js
+++ b/scripts/chromeDetection.js
@@ -218,7 +218,7 @@ async function isSuitableVersion(executablePath) {
   let versionOutput
   // in case installed Chrome is not runnable
   try {
-    versionOutput = execSync(`${executablePath} --version`).toString()
+    versionOutput = execSync(`"${executablePath}" --version`).toString()
   } catch (e) {
     return false
   }


### PR DESCRIPTION
Hi! Thanks for `estimo`! I was getting this on a Mac (zsh):

```sh
> estimo@1.1.5 install /Users/.../node_modules/estimo
> node ./scripts/findChrome.js

/bin/sh: /Applications/Google: No such file or directory
Local Chrome version is not suitable
Downloading Chromium r674921...
```

^ Seemed like the command skipped everything after the space character.

With this PR I’m now getting this:

```sh
❯ node node_modules/estimo/scripts/findChrome.js
Local Chrome location: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
```

I’m not 100% certain :)

https://unix.stackexchange.com/questions/108635/why-i-cant-escape-spaces-on-a-bash-script#108638