### PR TITLE
Libs parameter improvements: validate file paths; allow HTML URLs instead of file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ estimo -l ./libs/someLib.js ./libs/myLib.js
 const report = await estimo(['/path/to/libs/someLib.js', '/path/to/libs/myLib.js'])
 ```
 
+## HTML URLs
+
+You can also pass URLs to HTML pages served over HTTP(S)
+
+```sh
+estimo -l http://localhost:8080/myLib.html
+```
+
+```js
+const report = await estimo(['http://localhost:8080/myLib.html'])
+```
+
 ## Time
 
 **All metrics in milliseconds**.

--- a/src/generateHtmlFiles.js
+++ b/src/generateHtmlFiles.js
@@ -1,5 +1,5 @@
 const nanoid = require('nanoid')
-const { getLibraryName, writeFile, resolvePathToTempDir } = require('./utils')
+const { getLibraryName, writeFile, resolvePathToTempDir, assureFileExists } = require('./utils')
 
 function prepareHtmlContent(lib) {
   return `
@@ -24,6 +24,7 @@ async function generateHtmlFiles(libs) {
 
   for (const lib of modules) {
     try {
+      assureFileExists(lib)
       const fileName = resolvePathToTempDir(`${nanoid()}.html`)
       const fileContent = prepareHtmlContent(lib)
       await writeFile(fileName, fileContent)

--- a/src/generateHtmlFiles.js
+++ b/src/generateHtmlFiles.js
@@ -1,5 +1,5 @@
 const nanoid = require('nanoid')
-const { getLibraryName, writeFile, resolvePathToTempDir, assureFileExists } = require('./utils')
+const { getLibraryName, writeFile, resolvePathToTempDir, assureFileExists, isHttp } = require('./utils')
 
 function prepareHtmlContent(lib) {
   return `
@@ -24,10 +24,16 @@ async function generateHtmlFiles(libs) {
 
   for (const lib of modules) {
     try {
-      assureFileExists(lib)
-      const fileName = resolvePathToTempDir(`${nanoid()}.html`)
-      const fileContent = prepareHtmlContent(lib)
-      await writeFile(fileName, fileContent)
+      let fileName;
+      if (isHttp(lib)) {
+        fileName = lib
+      }
+      else {
+        assureFileExists(lib)
+        fileName = resolvePathToTempDir(`${nanoid()}.html`)
+        const fileContent = prepareHtmlContent(lib)
+        await writeFile(fileName, fileContent)
+      }
       htmlFiles.push({ name: getLibraryName(lib), html: fileName })
     } catch (error) {
       console.error(error.stack)

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,18 @@ function resolvePathToTempDir(fileName, tempDir = '../temp/') {
   return path.join(__dirname, tempDir, fileName)
 }
 
+async function assureFileExists(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`${filePath} - file not exist!`)
+    }
+    return true
+  } catch (error) {
+    console.error(error.stack)
+    return process.exit(1)
+  }
+}
+
 async function readFile(filePath) {
   try {
     if (!fs.existsSync(filePath)) {
@@ -64,6 +76,7 @@ function getLibraryName(lib) {
 
 module.exports = {
   resolvePathToTempDir,
+  assureFileExists,
   getUrlToHtmlFile,
   megabitsToBytes,
   removeTempFiles,

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,7 +53,14 @@ async function deleteFile(filePath) {
   }
 }
 
+function isHttp(file) {
+  return (file.indexOf('http://') === 0 || file.indexOf('https://') === 0)
+}
+
 function getUrlToHtmlFile(file) {
+  if (isHttp(file)) {
+    return file
+  }
   return `file://${path.resolve(file)}`
 }
 
@@ -63,7 +70,9 @@ function megabitsToBytes(megabits) {
 
 async function removeTempFiles(files) {
   for (const file of files) {
-    await deleteFile(file)
+    if (!isHttp(file)) {
+      await deleteFile(file)
+    }
   }
 }
 
@@ -77,6 +86,7 @@ function getLibraryName(lib) {
 module.exports = {
   resolvePathToTempDir,
   assureFileExists,
+  isHttp,
   getUrlToHtmlFile,
   megabitsToBytes,
   removeTempFiles,


### PR DESCRIPTION
This PR introduces two changes to parsing of `-l` parameter that I found needed:

1. Validate the JS file path, so that providing an unexisting file path results in an error
2. Allow to provide a URL to HTML file instead of a JS file path. This allows to use things that don't work in `file://` protocol, such as `fetch` and ES Modules.

Great project @mbalabash!