### PR TITLE
Use PUPPETEER_EXECUTABLE_PATH variable if available

### DIFF
--- a/src/create-chrome-trace.js
+++ b/src/create-chrome-trace.js
@@ -6,7 +6,7 @@ const chromeConfig = require('../chrome.json')
 const defaultBrowserOptions = {
   headless: true,
   timeout: 20000,
-  executablePath: chromeConfig.executablePath,
+  executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || chromeConfig.executablePath,
 }
 
 async function createChromeTrace(resources, browserOptions) {


### PR DESCRIPTION
It allows indirect users (such as ones using size-limit) to specify chrome executable through ENV variable compatible with Puppeteer.

Added this way it will have higher priority than executable found on postinstall, but smaller priority than the one specified in function parameter. I think it's reasonable enough.